### PR TITLE
[Feat] 상태 관리 기능 추가(로그인 모달/ 유저 토큰 값 변경)

### DIFF
--- a/src/pages/login/LoginCallback.tsx
+++ b/src/pages/login/LoginCallback.tsx
@@ -37,6 +37,8 @@ function LoginCallback() {
               token: accessToken,
             });
 
+            localStorage.setItem("isLoggedIn", "true");
+
             switch (loginStatus) {
               case "signup":
                 navigate("/signup");
@@ -62,11 +64,6 @@ function LoginCallback() {
         } else {
           console.error("알 수 없는 오류 발생:", error);
         }
-        setAuth({
-          isLoggedIn: false,
-          username: null,
-          token: null,
-        });
       }
     };
 

--- a/src/pages/login/LoginCallback.tsx
+++ b/src/pages/login/LoginCallback.tsx
@@ -24,7 +24,7 @@ function LoginCallback() {
           }
         );
 
-        console.log("응답 데이터:", response);
+        // console.log("응답 헤더:", response.headers);
 
         if (response.status === 200) {
           const accessToken = response.headers["access"];

--- a/src/pages/main/main.tsx
+++ b/src/pages/main/main.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from "react";
 import * as styles from "./main.styles";
 import { useNavigate } from "react-router-dom";
+import { authState } from "../../atoms/authState";
+import { useRecoilValue } from "recoil";
 import LeftButton from "../../assets/LeftButton.svg";
 import RightButton from "../../assets/RightButton.svg";
 
@@ -17,13 +19,17 @@ function Main() {
   const [mentorData, setMentorData] = useState<MentorData[] | null>(null);
   const navigate = useNavigate();
   const [currentIndex, setCurrentIndex] = useState(0);
-
-  useEffect(() => {}, [activeButtons]);
+  const { token } = useRecoilValue(authState);
 
   useEffect(() => {
-    const token = process.env.REACT_APP_TOKEN;
-    // process.env.REACT_APP_TOKEN;
-    const url = `https://cogo.run/api/v1/mentor/BE`;
+    const isLoggedIn = localStorage.getItem("isLoggedIn") === "true";
+    if (!isLoggedIn) {
+      navigate("/login");
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    const url = `https://cogo.life/api/v1/mentor/BE`;
 
     fetch(url, {
       method: "GET",

--- a/src/pages/signup/signup.tsx
+++ b/src/pages/signup/signup.tsx
@@ -1,6 +1,8 @@
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import { useState, ChangeEvent, useEffect } from "react";
+import { authState } from "../../atoms/authState";
+import { useRecoilValue } from "recoil";
 import LeftArrow from "../../assets/ArrowLeft.svg";
 import BlackLine from "../../assets/BlackLine.svg";
 import * as styles from "./signup.styles";
@@ -9,6 +11,7 @@ import * as styles from "./signup.styles";
 
 function SignUp() {
   const navigate = useNavigate();
+  const { token } = useRecoilValue(authState);
   const [email, setEmail] = useState<string>("");
   const [domain, setDomain] = useState<string>("@self");
   const [code, setCode] = useState<string>("");
@@ -35,9 +38,7 @@ function SignUp() {
     navigate("/");
   };
 
-  useEffect(() => {
-    // 클릭한 분야 변경 시 데이터 가져오기
-  }, [activeButton]);
+  useEffect(() => {}, [activeButton]);
 
   const handleButtonClick = (buttonName: string) => {
     setActiveButton((prev) => (prev === buttonName ? "" : buttonName));
@@ -52,7 +53,6 @@ function SignUp() {
   };
 
   const sendEmail = () => {
-    const token = process.env.REACT_APP_TOKEN;
     const link = getEmailLink();
 
     axios
@@ -83,7 +83,6 @@ function SignUp() {
   };
 
   const submitSignUp = () => {
-    const token = process.env.REACT_APP_TOKEN;
     const url = "https://cogo.life/api/v1/user/join/mentee";
     const userData = {
       email: `${email}${domain}`,


### PR DESCRIPTION
## **변경 사항 요약**

- 상태 관리 기능 추가: 로그인한 유저가 아닐 경우 로그인 모달 띄우기
- 유저 토큰 값 변경: 마스터 토큰에서 로그인 시 토큰으로 값 변경
- 구글 오어스 성공 : main브랜치로 코드 쐈어서 여기 이슈에 이야기 남겨 놓습니다.

## **이슈번호**

- #9 
- #30 
- #27

## **주요 변경 사항**

- pages의 login 폴더
- pages의 signup 폴더
- pages의 main 폴더

## **스크린샷 (해당되는 경우)**

[미로그인 유저 시 메인으로 이동 불가]
[이미 추가정보를 기입한 계정이라 바로 메인으로 이동함]
- #27

https://github.com/Soongsil-CoffeeChat/CoffeeChat-Client/assets/104755384/f66877ec-221b-4766-8aa8-0ceac8f539a1

[추가정정보 미기입 시]
[추가 정보 기입을 안했던 계정- signup페이지로 이동함]
- #9 

https://github.com/Soongsil-CoffeeChat/CoffeeChat-Client/assets/104755384/c8c65875-0347-4527-b7b6-6f44d86b5634



